### PR TITLE
Bump postcss to 5.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = postcss.plugin('postcss-strip', function () {
             }, node.source);
         }
 
-        css.eachInside(function (node) {
+        css.walk(function (node) {
             if (node.type === 'atrule') {
                 return transformValue(node, 'params');
             } else if (node.type === 'decl') {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/whitneyit/postcss-strip-units",
   "dependencies": {
-    "postcss": "^4.1.13",
+    "postcss": "^5.0.14",
     "postcss-message-helpers": "^2.0.0",
     "reduce-function-call": "^1.0.1"
   },


### PR DESCRIPTION
`eachInside` was deprecated in favor of `walk`